### PR TITLE
ADD operator managed minio for data science pipeline

### DIFF
--- a/helm/configure-pipeline/templates/pipeline.yaml
+++ b/helm/configure-pipeline/templates/pipeline.yaml
@@ -4,19 +4,33 @@ kind: DataSciencePipelinesApplication
 metadata:
   name: dspa
 spec:
-  dspVersion: v2
-  objectStorage:
-    externalStorage:
-      host: {{ .Values.minio.host }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.minio.port }}
-      scheme: http
-      bucket: {{ .Release.Namespace }}-pipeline
-      region: {{ .Values.minio.region }}
-      s3CredentialsSecret:
-        accessKey: AWS_ACCESS_KEY_ID
-        secretKey: AWS_SECRET_ACCESS_KEY
-        secretName: dashboard-dspa-secret
   apiServer:
+    artifactSignedURLExpirySeconds: 60
+    caBundleFileMountPath: ''
+    caBundleFileName: ''
+    deploy: true
+    enableOauth: true
     enableSamplePipeline: false
     managedPipelines:
       instructLab:
         state: Removed
+  database:
+    disableHealthCheck: false
+    mariaDB:
+      deploy: true
+      pipelineDBName: mlpipeline
+      pvcSize: 10Gi
+      username: mlpipeline
+  dspVersion: v2
+  objectStorage:
+    minio:  # mutually exclusive with externalStorage
+      deploy: true
+      image: 'quay.io/minio/minio:latest'
+    enableExternalRoute: false
+  persistenceAgent:
+    deploy: true
+    numWorkers: 2
+  podToPodTLS: true
+  scheduledWorkflow:
+    cronScheduleTimezone: UTC
+    deploy: true


### PR DESCRIPTION
In this PR we added a configuration for a built-in, operator managed, minio instance for the data science pipeline. It prevents any dependencies issues while deploying helm charts for minio.