### PR TITLE
Adding mcp db store helm chart

### DIFF
--- a/helm/mcp-dbstore/Chart.yaml
+++ b/helm/mcp-dbstore/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: mcp-dbstore
+description: A Helm chart for deploying MCP DBStore server with PostgreSQL database
+type: application
+version: 0.1.0
+appVersion: "0.0.1"
+keywords:
+  - mcp
+  - model-context-protocol
+  - database
+  - fastmcp
+  - llama-stack
+home: https://github.com/yourusername/ai-virtual-assistant
+sources:
+  - https://github.com/yourusername/ai-virtual-assistant/tree/main/mcpservers/mcp_dbstore
+maintainers:
+  - name: AI Virtual Assistant Team
+    email: team@example.com
+annotations:
+  category: AI/ML Tools
+dependencies: [] 

--- a/helm/mcp-dbstore/README.md
+++ b/helm/mcp-dbstore/README.md
@@ -1,0 +1,289 @@
+# MCP DBStore Helm Chart
+
+A Helm chart for deploying the MCP DBStore server with PostgreSQL database on Kubernetes.
+
+## Overview
+
+This chart deploys a complete Model Context Protocol (MCP) server that provides database-backed product inventory tools. The deployment includes:
+
+- **MCP DBStore Server**: FastMCP-based server with 7 inventory management tools
+- **PostgreSQL Database**: Persistent database with sample data initialization
+- **Service Discovery**: Kubernetes services for internal cluster communication
+- **Security**: RBAC, security contexts, and secret management
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure (for PostgreSQL persistence)
+
+## Installation
+
+### Quick Start
+
+```bash
+# Install from local chart
+helm install my-mcp-dbstore ./deploy/helm/mcp-dbstore
+```
+
+### Custom Installation
+
+```bash
+# Install with custom values
+helm install my-mcp-dbstore ./deploy/helm/mcp-dbstore \
+  --set postgresql.auth.password=mysecretpassword \
+  --set mcpServer.image.tag=latest \
+  --set postgresql.persistence.size=5Gi
+
+# Install in custom namespace
+kubectl create namespace mcp-servers
+helm install my-mcp-dbstore ./deploy/helm/mcp-dbstore -n mcp-servers
+```
+
+## Configuration
+
+### Global Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `global.imageRegistry` | Global Docker image registry | `""` |
+| `global.imagePullSecrets` | Global Docker registry secret names | `[]` |
+| `global.storageClass` | Global StorageClass for Persistent Volume(s) | `""` |
+
+### MCP Server Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mcpServer.enabled` | Enable MCP server deployment | `true` |
+| `mcpServer.image.registry` | MCP server image registry | `quay.io` |
+| `mcpServer.image.repository` | MCP server image repository | `skattoju/mcp_dbstore` |
+| `mcpServer.image.tag` | MCP server image tag | `0.0.1` |
+| `mcpServer.image.pullPolicy` | MCP server image pull policy | `IfNotPresent` |
+| `mcpServer.replicaCount` | Number of MCP server replicas | `1` |
+| `mcpServer.service.type` | MCP server service type | `ClusterIP` |
+| `mcpServer.service.port` | MCP server service port | `8002` |
+| `mcpServer.resources.limits.cpu` | MCP server CPU limit | `500m` |
+| `mcpServer.resources.limits.memory` | MCP server memory limit | `512Mi` |
+| `mcpServer.resources.requests.cpu` | MCP server CPU request | `100m` |
+| `mcpServer.resources.requests.memory` | MCP server memory request | `128Mi` |
+
+### PostgreSQL Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `postgresql.enabled` | Enable PostgreSQL deployment | `true` |
+| `postgresql.image.registry` | PostgreSQL image registry | `docker.io` |
+| `postgresql.image.repository` | PostgreSQL image repository | `postgres` |
+| `postgresql.image.tag` | PostgreSQL image tag | `15-alpine` |
+| `postgresql.auth.username` | PostgreSQL username | `mcpuser` |
+| `postgresql.auth.password` | PostgreSQL password | `mcppassword` |
+| `postgresql.auth.database` | PostgreSQL database name | `store_db` |
+| `postgresql.persistence.enabled` | Enable PostgreSQL persistence | `true` |
+| `postgresql.persistence.size` | PostgreSQL persistent volume size | `2Gi` |
+| `postgresql.persistence.storageClass` | PostgreSQL storage class | `""` |
+| `postgresql.initdb.enabled` | Enable database initialization with sample data | `true` |
+
+### Security Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.name` | Service account name | `""` |
+| `podSecurityContext.runAsNonRoot` | Run containers as non-root | `true` |
+| `securityContext.allowPrivilegeEscalation` | Allow privilege escalation | `false` |
+
+## Usage
+
+### Accessing the MCP Server
+
+After installation, you can access the MCP server:
+
+```bash
+# Port forward to access from local machine
+kubectl port-forward svc/my-mcp-dbstore-mcp-server 8002:8002
+
+# Test connection
+curl http://localhost:8002/health
+```
+
+### Using MCP Inspector
+
+```bash
+# Install MCP inspector
+pip install mcp-inspector
+
+# Inspect the server tools
+mcp-inspector http://localhost:8002
+```
+
+### Database Access
+
+```bash
+# Port forward PostgreSQL
+kubectl port-forward svc/my-mcp-dbstore-postgresql 5432:5432
+
+# Get database password
+kubectl get secret my-mcp-dbstore-postgresql -o jsonpath="{.data.password}" | base64 --decode
+
+# Connect with psql
+psql -h localhost -U mcpuser -d store_db
+```
+
+## Available Tools
+
+The MCP server provides these tools for LLM agents:
+
+1. **get_products** - Retrieve paginated product list
+2. **get_product_by_id** - Get specific product details
+3. **get_product_by_name** - Find product by exact name
+4. **search_products** - Search products by query string
+5. **add_product** - Create new product in inventory
+6. **remove_product** - Delete product by ID
+7. **order_product** - Place product order (updates inventory)
+
+## Llama Stack Integration
+
+Register with Llama Stack for agent usage:
+
+```bash
+# Register the MCP server
+llamastack mcp-server register \
+  --name mcp-dbstore \
+  --url http://my-mcp-dbstore-mcp-server.default.svc.cluster.local:8002 \
+  --description "Product inventory management tools"
+
+# Verify registration
+llamastack mcp-server list
+
+# Use in agent configuration
+llamastack agent create \
+  --name inventory-agent \
+  --tool-groups mcp-dbstore
+```
+
+## Monitoring
+
+### Health Checks
+
+```bash
+# Check pod status
+kubectl get pods -l app.kubernetes.io/name=mcp-dbstore
+
+# Check service endpoints
+kubectl get endpoints
+
+# View logs
+kubectl logs -f deployment/my-mcp-dbstore-mcp-server
+kubectl logs -f deployment/my-mcp-dbstore-postgresql
+```
+
+### Metrics (if enabled)
+
+```bash
+# View service monitor (if monitoring.enabled=true)
+kubectl get servicemonitor -l app.kubernetes.io/name=mcp-dbstore
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **MCP Server won't start**
+   ```bash
+   # Check init container logs
+   kubectl logs deployment/my-mcp-dbstore-mcp-server -c wait-for-db
+   
+   # Check database connectivity
+   kubectl exec -it deployment/my-mcp-dbstore-postgresql -- pg_isready
+   ```
+
+2. **Database connection issues**
+   ```bash
+   # Verify secret exists
+   kubectl get secret my-mcp-dbstore-postgresql
+   
+   # Check database URL
+   kubectl get secret my-mcp-dbstore-mcp-server -o yaml
+   ```
+
+3. **Persistent volume issues**
+   ```bash
+   # Check PVC status
+   kubectl get pvc
+   
+   # Check storage class
+   kubectl get storageclass
+   ```
+
+### Debug Mode
+
+Enable debug logging:
+
+```bash
+helm upgrade my-mcp-dbstore ./deploy/helm/mcp-dbstore \
+  --set mcpServer.env.PYTHONPATH=/app \
+  --set mcpServer.env.LOG_LEVEL=DEBUG
+```
+
+## Upgrading
+
+```bash
+# Upgrade with new values
+helm upgrade my-mcp-dbstore ./deploy/helm/mcp-dbstore \
+  --set mcpServer.image.tag=0.0.2
+
+# Rollback if needed
+helm rollback my-mcp-dbstore 1
+```
+
+## Uninstalling
+
+```bash
+# Uninstall the release
+helm uninstall my-mcp-dbstore
+
+# Clean up PVCs (if needed)
+kubectl delete pvc data-my-mcp-dbstore-postgresql-0
+```
+
+## Development
+
+### Building Custom Images
+
+```bash
+# Build and push MCP server image
+docker build -t your-registry/mcp_dbstore:custom ./mcpservers/mcp_dbstore
+docker push your-registry/mcp_dbstore:custom
+
+# Use custom image
+helm install my-mcp-dbstore ./deploy/helm/mcp-dbstore \
+  --set mcpServer.image.registry=your-registry \
+  --set mcpServer.image.repository=mcp_dbstore \
+  --set mcpServer.image.tag=custom
+```
+
+### Local Development
+
+```bash
+# Run with development values
+helm install dev-mcp-dbstore ./deploy/helm/mcp-dbstore \
+  -f ./deploy/helm/mcp-dbstore/values-dev.yaml
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test with `helm lint` and `helm template`
+5. Submit a pull request
+
+## License
+
+This Helm chart is licensed under the Apache 2.0 License.
+
+## Support
+
+- GitHub Issues: https://github.com/yourusername/ai-virtual-assistant/issues
+- Documentation: https://github.com/yourusername/ai-virtual-assistant/tree/main/mcpservers/mcp_dbstore
+- MCP Protocol: https://modelcontextprotocol.io/docs/ 

--- a/helm/mcp-dbstore/templates/NOTES.txt
+++ b/helm/mcp-dbstore/templates/NOTES.txt
@@ -1,0 +1,107 @@
+1. Get the MCP DBStore server connection details:
+
+{{- if .Values.mcpServer.enabled }}
+  MCP Server Service: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+  Port: {{ .Values.mcpServer.service.port }}
+  
+  To connect to the MCP server from within the cluster:
+  
+    Service Name: {{ include "mcp-dbstore.fullname" . }}-mcp-server.{{ .Release.Namespace }}.svc.cluster.local
+    Port: {{ .Values.mcpServer.service.port }}
+    Protocol: {{ .Values.mcpServer.env.MCP_SERVER_TRANSPORT | default "sse" }}
+
+{{- if eq .Values.mcpServer.service.type "ClusterIP" }}
+  To access the MCP server from outside the cluster:
+  
+    kubectl port-forward svc/{{ include "mcp-dbstore.fullname" . }}-mcp-server {{ .Values.mcpServer.service.port }}:{{ .Values.mcpServer.service.port }} -n {{ .Release.Namespace }}
+    
+  Then connect to: http://localhost:{{ .Values.mcpServer.service.port }}
+{{- end }}
+
+{{- end }}
+
+{{- if .Values.postgresql.enabled }}
+
+2. Database connection details:
+
+  PostgreSQL Service: {{ include "mcp-dbstore.fullname" . }}-postgresql
+  Port: {{ .Values.postgresql.service.port }}
+  Database: {{ .Values.postgresql.auth.database }}
+  Username: {{ .Values.postgresql.auth.username }}
+
+  To connect to PostgreSQL from within the cluster:
+  
+    Host: {{ include "mcp-dbstore.fullname" . }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local
+    Port: {{ .Values.postgresql.service.port }}
+    Database: {{ .Values.postgresql.auth.database }}
+    
+  To access PostgreSQL from outside the cluster:
+  
+    kubectl port-forward svc/{{ include "mcp-dbstore.fullname" . }}-postgresql 5432:5432 -n {{ .Release.Namespace }}
+    
+  Get the database password:
+  
+    kubectl get secret {{ include "mcp-dbstore.fullname" . }}-postgresql -o jsonpath="{.data.password}" -n {{ .Release.Namespace }} | base64 --decode
+
+{{- end }}
+
+3. MCP Inspector Usage:
+
+  To inspect the MCP server tools using mcp-inspector:
+  
+    # Install mcp-inspector
+    pip install mcp-inspector
+    
+    # Connect to your MCP server (after port-forwarding)
+    mcp-inspector http://localhost:{{ .Values.mcpServer.service.port }}
+    
+  Available tools in this MCP server:
+    - get_products: Retrieve paginated product list
+    - get_product_by_id: Get specific product details
+    - get_product_by_name: Find product by exact name
+    - search_products: Search products by query
+    - add_product: Create new product
+    - remove_product: Delete product by ID
+    - order_product: Place product order
+
+4. Llama Stack Integration:
+
+  To register this MCP server with Llama Stack:
+  
+    # Register the MCP server
+    llamastack mcp-server register \
+      --name {{ include "mcp-dbstore.fullname" . }} \
+      --url http://{{ include "mcp-dbstore.fullname" . }}-mcp-server.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.mcpServer.service.port }} \
+      --description "Product inventory management MCP server"
+    
+    # Verify registration
+    llamastack mcp-server list
+    
+    # Tools will be auto-discovered and available as a toolgroup
+
+5. Monitoring and Logs:
+
+  Check MCP server logs:
+    kubectl logs -f deployment/{{ include "mcp-dbstore.fullname" . }}-mcp-server -n {{ .Release.Namespace }}
+  
+  Check PostgreSQL logs:
+    kubectl logs -f deployment/{{ include "mcp-dbstore.fullname" . }}-postgresql -n {{ .Release.Namespace }}
+  
+  Check pod status:
+    kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+6. Sample Data:
+
+{{- if .Values.postgresql.initdb.enabled }}
+  The database has been initialized with sample product data:
+  - 10 sample products with various categories
+  - Products include: Super Widget, Mega Gadget, Quantum Sprocket, etc.
+  - Test the tools by querying for these products
+{{- else }}
+  To populate the database with sample data, enable postgresql.initdb.enabled in values.yaml
+{{- end }}
+
+For more information:
+  Helm Chart: {{ .Chart.Name }} v{{ .Chart.Version }}
+  App Version: {{ .Chart.AppVersion }}
+  Documentation: https://github.com/yourusername/ai-virtual-assistant/tree/main/mcpservers/mcp_dbstore 

--- a/helm/mcp-dbstore/templates/_helpers.tpl
+++ b/helm/mcp-dbstore/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-dbstore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-dbstore.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-dbstore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-dbstore.labels" -}}
+helm.sh/chart: {{ include "mcp-dbstore.chart" . }}
+{{ include "mcp-dbstore.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-dbstore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-dbstore.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mcp-dbstore.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-dbstore.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name for MCP server
+*/}}
+{{- define "mcp-dbstore.mcpServer.image" -}}
+{{- $registryName := .Values.mcpServer.image.registry -}}
+{{- $repositoryName := .Values.mcpServer.image.repository -}}
+{{- $tag := .Values.mcpServer.image.tag | toString -}}
+{{- if .Values.global.imageRegistry }}
+    {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the proper image name for PostgreSQL
+*/}}
+{{- define "mcp-dbstore.postgresql.image" -}}
+{{- $registryName := .Values.postgresql.image.registry -}}
+{{- $repositoryName := .Values.postgresql.image.repository -}}
+{{- $tag := .Values.postgresql.image.tag | toString -}}
+{{- if .Values.global.imageRegistry }}
+    {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the proper storage class
+*/}}
+{{- define "mcp-dbstore.storageClass" -}}
+{{- if .Values.global.storageClass -}}
+    {{- .Values.global.storageClass -}}
+{{- else -}}
+    {{- .Values.postgresql.persistence.storageClass -}}
+{{- end -}}
+{{- end }} 

--- a/helm/mcp-dbstore/templates/configmap.yaml
+++ b/helm/mcp-dbstore/templates/configmap.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.initdb.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-postgresql-init
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  {{- range $key, $value := .Values.postgresql.initdb.scripts }}
+  {{ $key }}: |
+    {{- $value | nindent 4 }}
+  {{- end }}
+{{- end }} 

--- a/helm/mcp-dbstore/templates/mcp-server-deployment.yaml
+++ b/helm/mcp-dbstore/templates/mcp-server-deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.mcpServer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.mcpServer.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mcp-dbstore.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mcp-server
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-dbstore.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mcp-server
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-dbstore.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.mcpServer.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-db
+          image: postgres:15-alpine
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "mcp-dbstore.fullname" . }}-postgresql -p 5432 -U ${POSTGRES_USER}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 2
+              done
+              echo "PostgreSQL is ready!"
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+                  key: username
+      containers:
+        - name: mcp-server
+          securityContext:
+            {{- toYaml .Values.mcpServer.securityContext | nindent 12 }}
+          image: "{{ .Values.mcpServer.image.registry }}/{{ .Values.mcpServer.image.repository }}:{{ .Values.mcpServer.image.tag }}"
+          imagePullPolicy: {{ .Values.mcpServer.image.pullPolicy }}
+          ports:
+            - name: mcp-server
+              containerPort: {{ .Values.mcpServer.service.targetPort }}
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+                  key: database-url
+            {{- range $key, $value := .Values.mcpServer.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: mcp-server
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            tcpSocket:
+              port: mcp-server
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          resources:
+            {{- toYaml .Values.mcpServer.resources | nindent 12 }}
+      {{- with .Values.mcpServer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcpServer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.mcpServer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }} 

--- a/helm/mcp-dbstore/templates/postgresql-deployment.yaml
+++ b/helm/mcp-dbstore/templates/postgresql-deployment.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mcp-dbstore.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-dbstore.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: database
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-dbstore.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.postgresql.podSecurityContext | nindent 8 }}
+      containers:
+        - name: postgresql
+          securityContext:
+            {{- toYaml .Values.postgresql.securityContext | nindent 12 }}
+          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+                  key: database
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            {{- range $key, $value := .Values.postgresql.postgresqlConfiguration }}
+            - name: {{ $key | upper | replace "_" "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            {{- if .Values.postgresql.initdb.enabled }}
+            - name: init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.postgresql.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-dbstore.fullname" . }}-postgresql-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.postgresql.initdb.enabled }}
+        - name: init-scripts
+          configMap:
+            name: {{ include "mcp-dbstore.fullname" . }}-postgresql-init
+            defaultMode: 0755
+        {{- end }}
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }} 

--- a/helm/mcp-dbstore/templates/postgresql-pvc.yaml
+++ b/helm/mcp-dbstore/templates/postgresql-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-postgresql-data
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.postgresql.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.postgresql.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size | quote }}
+  {{- if .Values.postgresql.persistence.storageClass }}
+  {{- if (eq "-" .Values.postgresql.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }} 

--- a/helm/mcp-dbstore/templates/route.yaml
+++ b/helm/mcp-dbstore/templates/route.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.mcpServer.enabled .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+    weight: 100
+  port:
+    targetPort: mcp-server
+  {{- if .Values.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.route.tls.termination | default "edge" }}
+    {{- if .Values.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }} 

--- a/helm/mcp-dbstore/templates/secret.yaml
+++ b/helm/mcp-dbstore/templates/secret.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  postgres-password: {{ .Values.postgresql.auth.postgresPassword | b64enc | quote }}
+  password: {{ .Values.postgresql.auth.password | b64enc | quote }}
+  username: {{ .Values.postgresql.auth.username | b64enc | quote }}
+  database: {{ .Values.postgresql.auth.database | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  database-url: {{ printf "postgresql+asyncpg://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "mcp-dbstore.fullname" .) .Values.postgresql.auth.database | b64enc | quote }}
+{{- end }} 

--- a/helm/mcp-dbstore/templates/service.yaml
+++ b/helm/mcp-dbstore/templates/service.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-postgresql
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.postgresql.service.type }}
+  ports:
+    - port: {{ .Values.postgresql.service.port }}
+      targetPort: tcp-postgresql
+      protocol: TCP
+      name: tcp-postgresql
+  selector:
+    {{- include "mcp-dbstore.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+---
+{{- end }}
+{{- if .Values.mcpServer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-dbstore.fullname" . }}-mcp-server
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+  {{- with .Values.mcpServer.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.mcpServer.service.type }}
+  ports:
+    - port: {{ .Values.mcpServer.service.port }}
+      targetPort: {{ .Values.mcpServer.service.targetPort }}
+      protocol: TCP
+      name: mcp-server
+  selector:
+    {{- include "mcp-dbstore.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-server
+{{- end }} 

--- a/helm/mcp-dbstore/templates/serviceaccount.yaml
+++ b/helm/mcp-dbstore/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-dbstore.serviceAccountName" . }}
+  labels:
+    {{- include "mcp-dbstore.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }} 

--- a/helm/mcp-dbstore/values.yaml
+++ b/helm/mcp-dbstore/values.yaml
@@ -1,0 +1,205 @@
+# Default values for mcp-dbstore.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global settings
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+  storageClass: ""
+
+# MCP DBStore Server Configuration
+mcpServer:
+  enabled: true
+  image:
+    registry: quay.io
+    repository: ecosystem-appeng/mcp_dbstore
+    tag: "1.1.0"
+    pullPolicy: IfNotPresent
+  
+  replicaCount: 1
+  
+  service:
+    type: ClusterIP
+    port: 8002
+    targetPort: 8002
+    annotations: {}
+  
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  
+  # Environment variables for MCP server
+  env:
+    MCP_SERVER_PORT: "8002"
+    MCP_SERVER_HOST: "0.0.0.0"
+    MCP_SERVER_TRANSPORT: "sse"
+  
+  # Pod Security Context - Empty for OpenShift compatibility
+  podSecurityContext: {}
+  
+  # Container Security Context - Minimal for OpenShift compatibility
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: false
+
+# PostgreSQL Database Configuration
+postgresql:
+  enabled: true
+  
+  image:
+    registry: docker.io
+    repository: postgres
+    tag: "15-alpine"
+    pullPolicy: IfNotPresent
+  
+  # Database configuration
+  auth:
+    enablePostgresUser: true
+    postgresPassword: "mcppassword"
+    username: "mcpuser"
+    password: "mcppassword"
+    database: "store_db"
+  
+  service:
+    type: ClusterIP
+    port: 5432
+  
+  # Persistence configuration
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 2Gi
+    annotations: {}
+  
+  # Resource configuration
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  
+  # Security context - Empty for OpenShift compatibility
+  podSecurityContext: {}
+  
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: false
+  
+  # PostgreSQL configuration
+  postgresqlConfiguration:
+    max_connections: 100
+    shared_buffers: 128MB
+    effective_cache_size: 256MB
+  
+  # Init container for database seeding
+  initdb:
+    enabled: true
+    scripts:
+      populate-db.sql: |
+        -- Create the products table first
+        CREATE TABLE IF NOT EXISTS products (
+          id SERIAL PRIMARY KEY,
+          name VARCHAR(255) NOT NULL,
+          description TEXT,
+          inventory INTEGER NOT NULL DEFAULT 0,
+          price DECIMAL(10, 2) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        
+        -- Sample data for the products table
+        INSERT INTO products (name, description, inventory, price) VALUES
+        ('Super Widget', 'A high-quality widget with advanced features and a sleek design.', 100, 29.99),
+        ('Mega Gadget', 'The latest gadget that everyone is talking about. Packed with power.', 50, 79.50),
+        ('Awesome Gizmo', 'A versatile gizmo for all your daily needs. Simple and effective.', 200, 12.75),
+        ('Hyper Doodad', 'Experience the next level of doodads with this hyper-efficient model.', 75, 45.00),
+        ('Ultra Thingamajig', 'The ultimate thingamajig, built for performance and durability.', 120, 99.99),
+        ('Quantum Sprocket', 'A revolutionary sprocket utilizing quantum technology for unparalleled precision.', 30, 199.00),
+        ('Stealth Frob', 'A discreet frob that gets the job done without drawing attention.', 150, 22.50),
+        ('Cosmic Ratchet', 'A ratchet powerful enough to tighten bolts across galaxies. (Metaphorically)', 60, 65.20),
+        ('Zenith Component', 'The pinnacle of component design, offering superior integration.', 90, 33.80),
+        ('Nova Fastener', 'A new-age fastener that promises a secure hold every time.', 250, 5.95);
+
+# Service Account
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# Pod Disruption Budget
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Network Policy
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []
+
+# Monitoring
+monitoring:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+
+# Ingress configuration (if external access needed)
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: mcp-dbstore.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# OpenShift Route configuration (for external access)
+route:
+  enabled: true
+  host: ""  # Leave empty for auto-generated host
+  annotations: {}
+  tls:
+    enabled: true
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
+# Additional labels and annotations
+commonLabels: {}
+commonAnnotations: {}
+
+# Pod annotations
+podAnnotations: {}
+
+# Node selector for both components
+nodeSelector: {}
+
+# Tolerations for both components
+tolerations: []
+
+# Affinity rules for both components
+affinity: {} 


### PR DESCRIPTION
Adds an MCP server that allows interaction of llm based agents with a hypothetical store database. A number of example tools are defined that allow operations like looking up products, creating an order etc. This is primary meant to be a bare bones example and supposed to be distributed with ai-virtual-assistant kickstart. The ai-virtual-assistant repos github workflow needs to be updated to refer to this chart after it gets merged.