### PR TITLE
Adding Intel Gaudi support

### DIFF
--- a/helm/llm-service/files/tool_chat_template_llama3.2_pythonic.jinja
+++ b/helm/llm-service/files/tool_chat_template_llama3.2_pythonic.jinja
@@ -1,0 +1,98 @@
+{{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+    {%- set tools_in_user_message = false %}
+{%- endif %}
+{%- if not date_string is defined %}
+    {%- if strftime_now is defined %}
+        {%- set date_string = strftime_now("%d %b %Y") %}
+    {%- else %}
+        {%- set date_string = "26 Jul 2024" %}
+    {%- endif %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content']|trim %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "You are a helpful assistant with tool calling capabilities. Only reply with a tool call if the function exists in the library provided by the user. If it doesn't exist, just reply directly in natural language. When you receive a tool call response, use the output to format an answer to the original user question." %}
+{%- endif %}
+
+{#- System message #}
+{{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
+{%- if tools is not none %}
+    {{- "Environment: ipython\n" }}
+{%- endif %}
+{{- "Cutting Knowledge Date: December 2023\n" }}
+{{- "Today Date: " + date_string + "\n\n" }}
+{%- if tools is not none and not tools_in_user_message %}
+    {{- "You have access to the following functions. To call functions, please respond with a python list of the calls. " }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+{%- endif %}
+{{- system_message }}
+{{- "<|eot_id|>" }}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+    {#- Extract the first user message so we can plug it in here #}
+    {%- if messages | length != 0 %}
+        {%- set first_user_message = messages[0]['content']|trim %}
+        {%- set messages = messages[1:] %}
+    {%- else %}
+        {{- raise_exception("Cannot put tools in the first user message when there's no first user message!") }}
+    {%- endif %}
+    {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+    {{- "Given the following functions, please respond with a python list for function calls " }}
+    {{- "with their proper arguments to best answer the given prompt.\n\n" }}
+    {{- 'Respond in the format [func_name1(params_name1=params_value1, params_name2=params_value2...), func_name2(params)] ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+    {{- first_user_message + "<|eot_id|>"}}
+{%- endif %}
+
+{%- for message in messages %}
+    {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
+    {%- elif 'tool_calls' in message %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n[' -}}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- tool_call.name + '(' -}}
+            {%- for param in tool_call.arguments %}
+                {{- param + '=' -}}
+                {{- "%s" | format(tool_call.arguments[param]) -}}
+                {% if not loop.last %}, {% endif %}
+            {%- endfor %}
+            {{- ')' -}}
+            {% if not loop.last %}, {% endif %}
+        {%- endfor %}
+        {{- ']<|eot_id|>' -}}
+    {%- elif message.role == "tool" or message.role == "ipython" %}
+        {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
+        {%- if message.content is mapping %}
+            {{- message.content | tojson }}
+        {%- else %}
+            {{- { "output": message.content } | tojson }}
+        {%- endif %}
+        {{- "<|eot_id|>" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}

--- a/helm/llm-service/templates/configmap.yaml
+++ b/helm/llm-service/templates/configmap.yaml
@@ -5,3 +5,5 @@ metadata:
 data:
   tool_chat_template_llama3.2_json.jinja: |-
 {{ .Files.Get "files/tool_chat_template_llama3.2_json.jinja" | indent 4 }}
+  tool_chat_template_llama3.2_pythonic.jinja: |-
+{{ .Files.Get "files/tool_chat_template_llama3.2_pythonic.jinja" | indent 4 }}

--- a/helm/llm-service/templates/inference-service.yaml
+++ b/helm/llm-service/templates/inference-service.yaml
@@ -2,6 +2,12 @@
 {{- $models := include "llm-service.mergeModels" . | fromJson }}
 {{- range $key, $model := $models }}
 {{- if and $model.enabled (not $model.url) }}
+{{- /* Device compatibility validation */ -}}
+{{- if $model.incompatibleDevices }}
+  {{- if has $root.Values.device $model.incompatibleDevices }}
+    {{- fail (printf "ERROR: Model '%s' is not compatible with device '%s'. This model is incompatible with: %s. Please use a different device or model." $key $root.Values.device ($model.incompatibleDevices | join ", ")) }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
@@ -13,31 +19,56 @@ metadata:
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
     storage.kserve.io/readonly: "false"
+    {{- if $root.Values.rawDeploymentMode }}
+    serving.kserve.io/deploymentMode: RawDeployment
+    {{- end }}
   labels:
     opendatahub.io/dashboard: "true"
     networking.knative.dev/visibility: "cluster-local"
 spec:
   predictor:
-    maxReplicas: 1
-    minReplicas: 1
+    maxReplicas: {{ $model.maxReplicas | default 1 }}
+    minReplicas: {{ $model.minReplicas | default 1 }}
     model:
       modelFormat:
         name: vLLM
       name: ""
-      resources:
       {{- if hasKey $model "resources" }}
-      {{- toYaml $model.resources | nindent 8 }}
-      {{- else }}
-      {{- if eq $root.Values.device "gpu" }}
+      resources:
+        {{- if or (eq $root.Values.device "gpu") (eq $root.Values.device "hpu") }}
+          {{- $deviceConfig := index $root.Values.deviceConfigs $root.Values.device }}
+          {{- $acceleratorType := $deviceConfig.acceleratorType }}
+          {{- $acceleratorCount := $model.accelerators | default "1" }}
+          {{- $customResources := $model.resources | deepCopy }}
+          {{- if $acceleratorType }}
+            {{- if not (hasKey $customResources.limits $acceleratorType) }}
+              {{- $_ := set $customResources.limits $acceleratorType $acceleratorCount }}
+            {{- end }}
+            {{- if not (hasKey $customResources.requests $acceleratorType) }}
+              {{- $_ := set $customResources.requests $acceleratorType $acceleratorCount }}
+            {{- end }}
+          {{- end }}
+          {{- toYaml $customResources | nindent 8 }}
+        {{- else }}
+          {{- toYaml $model.resources | nindent 8 }}
+        {{- end }}
+      {{- else if or (eq $root.Values.device "gpu") (eq $root.Values.device "hpu") }}
+      resources:
+      {{- $deviceConfig := index $root.Values.deviceConfigs $root.Values.device }}
+      {{- $acceleratorType := $deviceConfig.acceleratorType }}
+      {{- $acceleratorCount := $model.accelerators | default "1" }}
         limits:
           cpu: "2"
           memory: 8Gi
-          nvidia.com/gpu: "1"
+          {{- if $acceleratorType }}
+          {{ $acceleratorType }}: {{ $acceleratorCount | quote }}
+          {{- end }}
         requests:
           cpu: "1"
           memory: 4Gi
-          nvidia.com/gpu: "1"
-      {{- end }}
+          {{- if $acceleratorType }}
+          {{ $acceleratorType }}: {{ $acceleratorCount | quote }}
+          {{- end }}
       {{- end }}
       runtime: {{ $root.Values.servingRuntime.name }}
       storageUri: pvc://{{ $key }}/
@@ -53,13 +84,15 @@ spec:
       env:
         {{- toYaml . | nindent 6 }}
       {{- end }}
-    tolerations:
+    {{- $tolerations := list }}
     {{- if hasKey $model "tolerations" }}
-    {{- toYaml $model.tolerations | nindent 4 }}
-    {{- else }}
-    - key: nvidia.com/gpu
-      effect: NoSchedule
-      operator: Exists
+      {{- $tolerations = $model.tolerations }}
+    {{- else if hasKey $root.Values.deviceConfigs $root.Values.device }}
+      {{- $tolerations = (index $root.Values.deviceConfigs $root.Values.device).tolerations }}
+    {{- end }}
+    {{- if $tolerations }}
+    tolerations:
+    {{- toYaml $tolerations | nindent 4 }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/llm-service/templates/serving-runtime.yaml
+++ b/helm/llm-service/templates/serving-runtime.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Values.servingRuntime.name }}
   annotations:
     openshift.io/display-name: {{ .Values.servingRuntime.name }}
-    {{- with .Values.servingRuntime.recommendedAccelerators }}
-    opendatahub.io/recommended-accelerators: '{{ . | toJson }}'
+    {{- if and (hasKey .Values.deviceConfigs .Values.device) (index .Values.deviceConfigs .Values.device).recommendedAccelerators }}
+    opendatahub.io/recommended-accelerators: '{{ (index .Values.deviceConfigs .Values.device).recommendedAccelerators | toJson }}'
     {{- end }}
     opendatahub.io/apiProtocol: REST
     opendatahub.io/template-display-name: vLLM ServingRuntime for KServe
@@ -34,6 +34,8 @@ spec:
     {{- end }}
     {{- if eq .Values.device "gpu" }}
     image: {{ .Values.servingRuntime.gpuImage }}
+    {{- else if eq .Values.device "hpu" }}
+    image: {{ .Values.servingRuntime.hpuImage }}
     {{- else }}
     image: {{ .Values.servingRuntime.cpuImage }}
     {{- end }}

--- a/helm/llm-service/values.yaml
+++ b/helm/llm-service/values.yaml
@@ -1,12 +1,35 @@
-device: gpu
+device: hpu
+rawDeploymentMode: true
+
+# Device-specific configurations for tolerations and accelerators
+deviceConfigs:
+  gpu:
+    tolerations:
+      - key: nvidia.com/gpu
+        effect: NoSchedule
+        operator: Exists
+    recommendedAccelerators:
+      - nvidia.com/gpu
+    acceleratorType: nvidia.com/gpu
+  hpu:
+    tolerations:
+      - key: habana.ai/gaudi
+        effect: NoSchedule
+        operator: Exists
+    recommendedAccelerators:
+      - habana.ai/gaudi
+    acceleratorType: habana.ai/gaudi
+  cpu:
+    tolerations: []
+    recommendedAccelerators: []
+    acceleratorType: null
 
 servingRuntime:
   name: vllm-serving-runtime
   knativeTimeout: 60m
-  gpuImage: quay.io/ecosystem-appeng/vllm:openai-v0.8.5
-  cpuImage: quay.io/ecosystem-appeng/vllm:cpu-v0.8.5
-  recommendedAccelerators:
-    - nvidia.com/gpu
+  gpuImage: quay.io/ecosystem-appeng/vllm:openai-v0.9.2
+  cpuImage: quay.io/ecosystem-appeng/vllm:cpu-v0.9.2
+  hpuImage: quay.io/modh/vllm:vllm-gaudi-v2-22-on-push-jgj5q-build-container
   env:
     - name: HOME
       value: /vllm
@@ -28,8 +51,7 @@ servingRuntime:
         medium: Memory
         sizeLimit: 2Gi
     - name: vllm-home
-      emptyDir:
-        sizeLimit: 5Gi
+      emptyDir: {}
     - name: vllm-chat-templates
       configMap:
         name: vllm-chat-templates
@@ -42,6 +64,13 @@ models:
   llama-3-2-1b-instruct:
     id: meta-llama/Llama-3.2-1B-Instruct
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --enable-auto-tool-choice
       - --chat-template
@@ -49,18 +78,36 @@ models:
       - --tool-call-parser
       - llama3_json
       - --max-model-len
-      - "30544"
+      - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-guard-3-1b:
     id: meta-llama/Llama-Guard-3-1B
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --max-model-len
       - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-3-2-3b-instruct:
     id: meta-llama/Llama-3.2-3B-Instruct
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --enable-auto-tool-choice
       - --chat-template
@@ -68,24 +115,41 @@ models:
       - --tool-call-parser
       - llama3_json
       - --max-model-len
-      - "30544"
+      - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-guard-3-8b:
     id: meta-llama/Llama-Guard-3-8B
     enabled: false
+    resources:
+      limits:
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --max-model-len
       - "14336"
+      - --max-num-seqs
+      - "32"
 
   llama-3-1-8b-instruct:
     id: meta-llama/Llama-3.1-8B-Instruct
     enabled: false
     resources:
       limits:
-        nvidia.com/gpu: "1"
+        cpu: "2"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 16Gi
     args:
       - --max-model-len
       - "14336"
+      - --max-num-seqs
+      - "32"
       - --enable-auto-tool-choice
       - --chat-template
       - /chat-templates/tool_chat_template_llama3.2_json.jinja
@@ -96,9 +160,37 @@ models:
     id: meta-llama/Llama-3.3-70B-Instruct
     enabled: false
     storageSize: 150Gi
+    accelerators: "4"  # Number of accelerators needed different than 1
     resources:
       limits:
-        nvidia.com/gpu: "4"
+        cpu: "2"
+        memory: 300Gi
+      requests:
+        cpu: "1"
+        memory: 200Gi
+    args:
+      - --tensor-parallel-size
+      - "4"
+      - --gpu-memory-utilization
+      - "0.95"
+      - --max-num-batched-tokens
+      - "131074"
+      - --max-num-seqs
+      - "32"
+      - --enable-auto-tool-choice
+      - --chat-template
+      - /chat-templates/tool_chat_template_llama3.2_json.jinja
+      - --tool-call-parser
+      - llama3_json
+      - --swap-space
+      - "32"
+
+  llama-3-3-70b-instruct-fp8:
+    id: meta-llama/Llama-3.3-70B-Instruct
+    enabled: false
+    incompatibleDevices: ["hpu"]  # Device compatibility - quantized model doesn't work with HPU
+    storageSize: 150Gi
+    accelerators: "4"
     args:
       - --tensor-parallel-size
       - "4"
@@ -119,6 +211,7 @@ models:
   llama-3-2-1b-instruct-quantized:
     id: RedHatAI/Llama-3.2-1B-Instruct-quantized.w8a8
     enabled: false
+    incompatibleDevices: ["hpu"]
     args:
       - --gpu-memory-utilization
       - "0.4"


### PR DESCRIPTION
This PR adds support for Intel Gaudi HPUs alongside existing GPU and CPU support, implementing a device-aware configuration framework for the llm-service.

Template file [tool_chat_template_llama3.2_pythonic.jinja](https://github.com/RHEcosystemAppEng/ai-architecture-charts/compare/main...tbykowsk:ai-architecture-charts:gaudi-support?expand=1#diff-e105d79286b09ca53738911a8a4bfffde002f5b09cf43ceac548cf7ce0e939e0) and some additional changes were taken directly from https://rh-ai-quickstart.github.io/ai-architecture-charts/llm-service-0.1.0.tgz.

This llm-service has been validated as a dependency for [rh-ai-quickstart/RAG](https://github.com/rh-ai-quickstart/RAG/tree/main), with the intention of integrating it with RAG Kickstart as a next step.

Key Features:
- Add Intel Gaudi support with dedicated vLLM HPU container image
- Update remaining vLLM images from v0.8.5 to v0.9.2
- Add deviceConfigs structure with device-specific tolerations and accelerator configurations
- Add device-specific accelerator types (nvidia.com/gpu, habana.ai/gaudi)
- Support custom accelerator counts per model via device agnostic 'accelerators' field
- Add rawDeploymentMode configuration option
- Update model resources to handle vLLM warm-up on Gaudi HPU